### PR TITLE
fix not showing issues in large reports

### DIFF
--- a/src/main/resources/org/sonar/issuesreport/printer/html/issuesreport.ftl
+++ b/src/main/resources/org/sonar/issuesreport/printer/html/issuesreport.ftl
@@ -20,7 +20,7 @@
       <#if resourceReport_has_next>,</#if>
     </#list>
     ];
-    var nbResources = ${report.getResourcesWithReport()?size};
+    var nbResources = ${report.getResourcesWithReport()?size?c};
     var separators = new Array();
 
     function showLine(fileIndex, lineId) {


### PR DESCRIPTION
When a report has above 1000 issues in total, the nbResources variable is
printed with a thousand separator. This caused the filter loop to exit.
The solution is to print any numbers for the js snippet as raw (?c).